### PR TITLE
fix strip count checks and header includes

### DIFF
--- a/src/PixelPusher.cpp
+++ b/src/PixelPusher.cpp
@@ -110,7 +110,7 @@ void PixelPusher::addStrip(std::shared_ptr<Strip> strip) {
 }
 
 std::shared_ptr<Strip> PixelPusher::getStrip(int stripNumber) {
-	if (stripNumber < mStrips.size() - 1) {
+	if (stripNumber < mStrips.size()) {
 		return mStrips.at(stripNumber);
 	}
 	else {
@@ -124,7 +124,7 @@ int PixelPusher::getMaxStripsPerPacket() {
 }
 
 int PixelPusher::getPixelsPerStrip(int stripNumber) {
-	if (stripNumber < mStrips.size() - 1) {
+	if (stripNumber < mStrips.size()) {
 		return mStrips.at(stripNumber)->getLength();
 	}
 	else {
@@ -134,7 +134,7 @@ int PixelPusher::getPixelsPerStrip(int stripNumber) {
 }
 
 void PixelPusher::setStripValues(int stripNumber, unsigned char red, unsigned char green, unsigned char blue) {
-	if (stripNumber < mStrips.size() - 1) {
+	if (stripNumber < mStrips.size()) {
 		mStrips.at(stripNumber)->setPixels(red, green, blue);
 	}
 	else {
@@ -143,7 +143,7 @@ void PixelPusher::setStripValues(int stripNumber, unsigned char red, unsigned ch
 }
 
 void PixelPusher::setStripValues(int stripNumber, std::vector<std::shared_ptr<Pixel> > pixels) {
-	if (stripNumber < mStrips.size() - 1) {
+	if (stripNumber < mStrips.size()) {
 		mStrips.at(stripNumber)->setPixels(pixels);
 	}
 	else {
@@ -158,7 +158,7 @@ void PixelPusher::setPowerScale(double powerScale) {
 }
 
 void PixelPusher::setPowerScale(int stripNumber, double powerScale) {
-	if (stripNumber < mStrips.size() - 1) {
+	if (stripNumber < mStrips.size()) {
 		mStrips.at(stripNumber)->setPowerScale(powerScale);
 	}
 	else {
@@ -255,7 +255,7 @@ void PixelPusher::sendPacket() {
 
 			if (payload) {
 				if (mLogLevel == DEBUG) {
-					std::printf("PixelPusher::sendPacket -- Payload confirmed; sending packet of %d bytes", mPacket.size());
+					std::printf("PixelPusher::sendPacket -- Payload confirmed; sending packet of %lu bytes", mPacket.size());
 				}
 				mPacketNumber++;
 

--- a/src/Strip.cpp
+++ b/src/Strip.cpp
@@ -117,7 +117,7 @@ void Strip::setPixelsFromTex() {
 			scrapeTexture(subTexSrc, mSubTexWidth, mSubTexHeight, mTexDepth);
 
 			//do I need to free(subTexSrc)? or delete?
-			delete subTexSrc;
+			delete[] subTexSrc;
 		}
 		else {
 			scrapeTexture(mTexSrc, mTexWidth, mTexHeight, mTexDepth);

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
+#include <cstdio>
 
 namespace ofxPixelPusher {
 
@@ -141,3 +143,4 @@ namespace ofxPixelPusher {
 		return std::max(lower, std::min(n, upper));
 	}
 }
+


### PR DESCRIPTION
I'm not sure why stripNumber was checked with mStrips.size() - 1, but it didn't work for me, especially when testing with 1 strip only.
I've added some minor fixes so that clang doesn't complain and msbuild doesn't care.